### PR TITLE
Migrate README (with some changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# DCustomRPC: The Rewrite (the second part)!
+
+DCustomRPC is a custom rich presence client that you (you right there, yes you) can customize. You may remember the two Python versions of this, but this is the rewite (of the rewrite) in Rust! Now you don't have to worry about installing dependencies ~~(rust > python)~~!
+
+**DCustomRPC-v2 is not currently in production!!! Please either use the [old Python version](https://github.com/tazz4843/DCustomRPC), or wait for this one to be completed.**
+
+## Setup the Discord Application
+1. Firstly go to Discord Developers (https://discord.com/developers/applications/) and sign in.
+2. From here, click the "New App" button and enter a "App Name". This will show as what you are playing. "App Description" and "App Icon" do not matter for rich presence.
+3. After you have done this, you can copy the "Client ID" (under "App Details") and replace the client_id already in the config file.
+
+## Discord Prerequisites
+
+Please make sure that game statuses are turned on:
+
+![Game Toggle](https://i.imgur.com/V4FWevH.png)
+
+## Useful Links
+
+[Rust](https://rust-lang.org)
+
+[Repo Download: Stable](https://github.com/tazz4843/DCustomRPC-v2/archive/refs/heads/main.zip) 
+
+[Support Server](https://discord.gg/5yXExTsRye)


### PR DESCRIPTION
This PR aims to add a README.md similar to the old one (from v1). As you probably know, the exact configuration is not yet known, but I have simply added the static items (such as Discord, the introduction, and the useful links section).